### PR TITLE
Avoid NPEs in the replaceInMeta method

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.trophonix</groupId>
     <artifactId>TradePlus</artifactId>
-    <version>3.20</version>
+    <version>3.21</version>
 
     <properties>
         <res>${project.basedir}/res/</res>

--- a/src/main/java/com/trophonix/tradeplus/util/ItemFactory.java
+++ b/src/main/java/com/trophonix/tradeplus/util/ItemFactory.java
@@ -76,15 +76,20 @@ public class ItemFactory {
 
   public static ItemStack replaceInMeta(ItemStack item, String... replace) {
     item = item.clone();
+    if (!item.hasItemMeta()) return item;
     ItemMeta meta = item.getItemMeta();
     for (int i = 0; i < replace.length; i += 2) {
       String toReplace = replace[i];
       String replaceWith = replace[i + 1];
-      meta.setDisplayName(meta.getDisplayName().replace(toReplace, replaceWith));
-      List<String> lore = meta.hasLore() ? meta.getLore() : Collections.emptyList();
-      for (int j = 0; j < lore.size(); j++)
-        lore.set(j, lore.get(j).replace(toReplace, replaceWith));
-      meta.setLore(lore);
+      if (item.getItemMeta().hasDisplayName()) {
+        meta.setDisplayName(meta.getDisplayName().replace(toReplace, replaceWith));
+      }
+      if (meta.hasLore()) {
+        List<String> lore = meta.getLore();
+        for (int j = 0; j < lore.size(); j++)
+          lore.set(j, lore.get(j).replace(toReplace, replaceWith));
+        meta.setLore(lore);
+      }
     }
     item.setItemMeta(meta);
     return item;


### PR DESCRIPTION
Fixes #34 - a bug that could cause NullPointerException in certain circumstances. 