### PR TITLE
Fix GriefPrevention claimblock trades.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ target/
 org.eclipse.*
 *.lst
 pom.properties
+dependency-reduced-pom.xml

--- a/pom.xml
+++ b/pom.xml
@@ -148,7 +148,7 @@
         <dependency>
             <groupId>com.github.ProSavage</groupId>
             <artifactId>SavageFactions</artifactId>
-            <version>1.6.9.5-0.1.21-gbdd5473-400</version>
+            <version>1.6.3-RC</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/trophonix/tradeplus/extras/GriefPreventionExtra.java
+++ b/src/main/java/com/trophonix/tradeplus/extras/GriefPreventionExtra.java
@@ -17,7 +17,7 @@ public class GriefPreventionExtra extends Extra {
   @Override
   public double getMax(Player player) {
     PlayerData data = GriefPrevention.instance.dataStore.getPlayerData(player.getUniqueId());
-    return data.getAccruedClaimBlocks();
+    return data.getRemainingClaimBlocks();
   }
 
   @Override


### PR DESCRIPTION
Previously, players could trade already-spent claimblocks and essentially go into claimblock debt (i.e. they could claim land then trade those claimblocks as if they were still available). This small edit will only permit unused claimblocks to be traded, rather than the total accrued over time.

Maven automatically generated a `dependency-reduced-pom.xml` file so I went ahead and added it to `.gitignore` so it wouldn't get added to this commit. I also modified the SavageFactions dependency in `pom.xml` because the version previously defined wasn't resolving for me.