### PR TITLE
Fix stackoverflow by converting TradeLogs to Strings on write

### DIFF
--- a/src/main/java/com/trophonix/tradeplus/logging/Logs.java
+++ b/src/main/java/com/trophonix/tradeplus/logging/Logs.java
@@ -56,7 +56,7 @@ public class Logs implements List<TradeLog> {
 //    if (folder.exists() && (contents = folder.listFiles()) != null) {
 //      for (File child : contents) {
 //        FileReader reader = new FileReader(child);
-//        add(gson.fromJson(reader, TradeLog.class));
+//        add(gson.fromJson(reader, String.class));
 //        reader.close();
 //      }
 //    }
@@ -86,7 +86,7 @@ public class Logs implements List<TradeLog> {
                       .replace("{player2}", log.getPlayer2().getLastKnownName()));
           if (!file.exists()) file.createNewFile();
           FileWriter writer = new FileWriter(file);
-          gson.toJson(log, TradeLog.class, writer);
+          gson.toJson(log.toString(), String.class, writer);
           writer.close();
         } catch (IOException ex) {
           System.out.println(

--- a/src/main/java/com/trophonix/tradeplus/logging/TradeLog.java
+++ b/src/main/java/com/trophonix/tradeplus/logging/TradeLog.java
@@ -71,4 +71,17 @@ public class TradeLog implements PostProcessor {
       this.value = value;
     }
   }
+
+  @Override
+  public String toString() {
+    return "TradeLog{" +
+        "player1=" + player1 +
+        ", player2=" + player2 +
+        ", player1Items=" + player1Items +
+        ", player2Items=" + player2Items +
+        ", player1ExtraOffers=" + player1ExtraOffers +
+        ", player2ExtraOffers=" + player2ExtraOffers +
+        ", time=" + time +
+        '}';
+  }
 }


### PR DESCRIPTION
This is totally untested as I wasn't able to pull the PluginBase dependency easily (#57), but should fix Trophonix/TradePlus#60 and fix Trophonix/TradePlus#62 if I didn't mess anything up.

I believe the root of the stackoverflow has something to do with ItemStack not being serializable (`org.bukkit.configuration.serialization.ConfigurationSerializable` != `java.io.Serializable`), so I've switched to using Strings.

I'm making an assumption in this patch that there shouldn't be a reason we would create a TradeLog from the string that is written to the file since that seems like overkill for basic logging. If that's a bad assumption, we should implement a better TypeAdapter that will handle the serialization of ItemStacks.

This small fix took me way longer than it should have, so if it works you owe me a coffee! :laughing:

Always happy to help!